### PR TITLE
Refactor: simpleCalculator for input validation

### DIFF
--- a/core-js-ts/tasks/basic-testing/basic-testing/src/01-simple-tests/index.ts
+++ b/core-js-ts/tasks/basic-testing/basic-testing/src/01-simple-tests/index.ts
@@ -21,26 +21,24 @@ type ValidCalculatorInput = {
 export const simpleCalculator = (
   rawInput: RawCalculatorInput,
 ): number | null => {
-  if (isInputValid(rawInput)) {
-    const { a, b, action } = rawInput;
-
-    switch (action) {
-      case Action.Add:
-        return a + b;
-      case Action.Subtract:
-        return a - b;
-      case Action.Multiply:
-        return a * b;
-      case Action.Divide:
-        return a / b;
-      case Action.Exponentiate:
-        return a ** b;
-      default:
-        throw new Error('Something went wrong!');
-    }
+  if (!isInputValid(rawInput)) {
+    return null;
   }
 
-  return null;
+  const { a, b, action } = rawInput;
+
+  switch (action) {
+    case Action.Add:
+      return a + b;
+    case Action.Subtract:
+      return a - b;
+    case Action.Multiply:
+      return a * b;
+    case Action.Divide:
+      return a / b;
+    case Action.Exponentiate:
+      return a ** b;
+  }
 };
 
 const isInputValid = (

--- a/core-js-ts/tasks/basic-testing/basic-testing/src/02-table-tests/index.ts
+++ b/core-js-ts/tasks/basic-testing/basic-testing/src/02-table-tests/index.ts
@@ -21,26 +21,24 @@ type ValidCalculatorInput = {
 export const simpleCalculator = (
   rawInput: RawCalculatorInput,
 ): number | null => {
-  if (isInputValid(rawInput)) {
-    const { a, b, action } = rawInput;
-
-    switch (action) {
-      case Action.Add:
-        return a + b;
-      case Action.Subtract:
-        return a - b;
-      case Action.Multiply:
-        return a * b;
-      case Action.Divide:
-        return a / b;
-      case Action.Exponentiate:
-        return a ** b;
-      default:
-        throw new Error('Something went wrong!');
-    }
+  if (!isInputValid(rawInput)) {
+    return null;
   }
 
-  return null;
+  const { a, b, action } = rawInput;
+
+  switch (action) {
+    case Action.Add:
+      return a + b;
+    case Action.Subtract:
+      return a - b;
+    case Action.Multiply:
+      return a * b;
+    case Action.Divide:
+      return a / b;
+    case Action.Exponentiate:
+      return a ** b;
+  }
 };
 
 const isInputValid = (


### PR DESCRIPTION
Refactored simpleCalculator to return null for invalid input earlier.
The `isInputValid` already covered the cases for switch conditioning. No need for the `default` throwable error.